### PR TITLE
ContructArgs arrar_merge array order bug

### DIFF
--- a/Service/MpdfService.php
+++ b/Service/MpdfService.php
@@ -15,7 +15,7 @@ class MpdfService {
 	{
 		$allConstructorArgs = $constructorArgs;
 		if($this->getAddDefaultConstructorArgs()) {
-			$allConstructorArgs = array_merge(array('utf-8', 'A4'),$allConstructorArgs);
+			$allConstructorArgs = array_merge(array('utf-8', 'A4'), $allConstructorArgs);
 		}		
 
 		$reflection = new \ReflectionClass('\mPDF');

--- a/Service/MpdfService.php
+++ b/Service/MpdfService.php
@@ -15,7 +15,7 @@ class MpdfService {
 	{
 		$allConstructorArgs = $constructorArgs;
 		if($this->getAddDefaultConstructorArgs()) {
-			$allConstructorArgs = array_merge($allConstructorArgs, array('utf-8', 'A4'));
+			$allConstructorArgs = array_merge(array('utf-8', 'A4'), $allConstructorArgs);
 		}		
 
 		$reflection = new \ReflectionClass('\mPDF');

--- a/Service/MpdfService.php
+++ b/Service/MpdfService.php
@@ -15,7 +15,7 @@ class MpdfService {
 	{
 		$allConstructorArgs = $constructorArgs;
 		if($this->getAddDefaultConstructorArgs()) {
-			$allConstructorArgs = array_merge(array('utf-8', 'A4'), $allConstructorArgs);
+			$allConstructorArgs = array_merge(array('utf-8', 'A4'),$allConstructorArgs);
 		}		
 
 		$reflection = new \ReflectionClass('\mPDF');


### PR DESCRIPTION
array_merge appends values of second array to the values of first array and so the array_merge arrays needed to be switched to respect the 
Mpdf argument acceptence order