### PR TITLE
Fix Symfony 4.2 deprecation warning

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,10 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('t_fox_mpdf_port');
+        $treeBuilder = new TreeBuilder('t_fox_mpdf_port');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root('t_fox_mpdf_port');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
Fix the configuration deprecation warning caused by a non-existing root node. See #37 