### PR TITLE
Allow extra options for mpdf

### DIFF
--- a/Service/PDFService.php
+++ b/Service/PDFService.php
@@ -31,11 +31,13 @@ class PDFService {
     public function generatePdf($html, $options = array())
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(array(
-            'mode' => 'utf-8',
-            'format' => 'A4',
-            'tempDir' => $this->cacheDir
-        ));
+        $resolver
+            ->setDefined(array_keys($options))
+            ->setDefaults(array(
+                'mode' => 'utf-8',
+                'format' => 'A4',
+                'tempDir' => $this->cacheDir
+            ));
         $options = $resolver->resolve($options);
         $mpdf = new Mpdf($options);
         $mpdf->WriteHTML($html);


### PR DESCRIPTION
Add extra options support for PDFService. With that fix, you will be able to add any mpdf options.

For example,
```php
$pdfService = new \TFox\MpdfPortBundle\Service\PDFService('/tmp');

$result = $pdfService->generatePdf('<b>test</b>', [
    'margin_left' => 0,
    'margin_right' => 0,
]);
```
Without fix that code will throw `UndefinedOptionsException`.